### PR TITLE
:bug: fix endless timeout on CI test

### DIFF
--- a/creates/async.js
+++ b/creates/async.js
@@ -1,4 +1,3 @@
-const defaults = require("./defaults");
 module.exports = {
   enqueueAndParse: async (z, inputDocument, apiOwner, apiName, apiVersion, headers, maxRetries = 60) => {
     const enqueueResponse = await z.request({
@@ -32,11 +31,10 @@ module.exports = {
           return parseQueuedResponse;
         }
       }
-    }
-    if (enqueueJson?.api_request?.error && Object.keys(enqueueJson.api_request.error).length > 0) {
-      throw new Error(JSON.stringify(enqueueJson.api_request.error));
+    } else if (enqueueJson?.api_request?.error && Object.keys(enqueueJson.api_request.error).length > 0) {
+      return Promise.reject(new Error(JSON.stringify(enqueueJson.api_request.error)));
     } else {
-      throw new Error(`Could not enqueue file properly.`);
+      return Promise.reject(new Error(`Could not enqueue file properly.`));
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Tweaked error returns for async calls so that invalid calls don't block the CI.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
